### PR TITLE
Add Turso to Drizzle docs

### DIFF
--- a/pages/packages/orm/drizzle.mdx
+++ b/pages/packages/orm/drizzle.mdx
@@ -7,7 +7,7 @@ Drizzle ORM is a TypeScript ORM for SQL databases designed with maximum type saf
 
 ### Dependencies Installed
 
-<Tabs items={['postgresjs', 'node-postgres', 'Neon', 'Vercel', 'Supabase', 'Planetscale', 'mysql-2', 'better-sqlite3']}>
+<Tabs items={['postgresjs', 'node-postgres', 'Turso', 'Neon', 'Vercel', 'Supabase', 'Planetscale', 'mysql-2', 'better-sqlite3']}>
 
 <Tab>
 * **Regular**
@@ -35,6 +35,20 @@ Drizzle ORM is a TypeScript ORM for SQL databases designed with maximum type saf
   * `tsx`
   * `dotenv`
   * `@types/pg`
+</Tab>
+
+<Tab>
+* **Regular**
+  * `drizzle-orm`
+  * `drizzle-zod`
+  * `@t3-oss/env-nextjs`
+  * `zod@3.21.4`
+  * `@libsql/client`
+* **Developer**
+  * `drizzle-kit`
+  * `tsx`
+  * `dotenv`
+  * `sqlite`
 </Tab>
 
 <Tab>


### PR DESCRIPTION
This PR adds Turso to the list of dependencies installed when used with Drizzle.