### PR TITLE
docs(auth.js): fix documentation link

### DIFF
--- a/pages/packages/auth/auth-js.mdx
+++ b/pages/packages/auth/auth-js.mdx
@@ -1,7 +1,7 @@
 # Auth.js
 Auth.js is a set of open-source packages that are built on Web Standard APIs for authentication in modern applications with any framework on any platform in any JS runtime.
 
-[Documentation](https://authjs.dev/getting-started/introduction)
+[Documentation](https://authjs.dev/getting-started)
 
 ### Dependencies Installed
 * Regular


### PR DESCRIPTION
The current link points to a non-existing page on the Auth.js website.

This PR fixes the link.

![image](https://github.com/nicoalbanese/kirimase-docs/assets/6183867/e27a92d6-f4b0-4bc9-b09a-f517503399fb)
